### PR TITLE
Fix java version error on compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,6 @@
 	<name>coincoinche</name>
 	<description>Website to play coinche online</description>
 
-	<properties>
-		<java.version>11</java.version>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This hardcoded java version in pom was preventing me to compile.
I removed it and I am able to compile and call the test controller successfully, so I assume we can just remove that.