### PR TITLE
Add basic tests for Hello Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@ For the moment, this repository only contains boilerplate from Spring Boot, as w
 For formatting java files, it is possible to use [google-java-format](https://github.com/google/google-java-format). To format all java files, run `java -jar google-java-format-1.7-all-deps.jar -i $(git ls-files|grep \.java$)`.
 
 ## Run the tests
+
+### Unit tests
+
 `./mvnw test`
 
 ## Build the application
+### Integration tests
 
 ### Linux
+`./mvnw failsafe:integration-test`
 
 `./mvnw package`
 

--- a/README.md
+++ b/README.md
@@ -13,16 +13,18 @@ For formatting java files, it is possible to use [google-java-format](https://gi
 
 `./mvnw test`
 
-## Build the application
 ### Integration tests
 
-### Linux
 `./mvnw failsafe:integration-test`
 
-`./mvnw package`
+## Build and run the application
 
-**NB:** if you want to skip style check, add the `-Dcheckstyle.skip` option.
+### Linux
 
-## Run the application
+You can build and run the application by using `./mvnw spring-boot:run`.
 
-`java -jar target/coincoinche-0.0.1-SNAPSHOT.jar`
+Alternatively, you can:
+- build the JAR file with `./mvnw clean package`
+- then run the JAR file with `java -jar target/coincoinche-0.0.1-SNAPSHOT.jar`
+
+**NB:** if you want to skip style check when building the application, add the `-Dcheckstyle.skip` option.

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
 					<configLocation>checkstyle.xml</configLocation>
 					<encoding>UTF-8</encoding>
 					<consoleOutput>true</consoleOutput>
-          <violationSeverity>warning</violationSeverity>
-          <failOnViolation>true</failOnViolation>
+					<violationSeverity>warning</violationSeverity>
+					<failOnViolation>true</failOnViolation>
 					<linkXRef>false</linkXRef>
 				</configuration>
 				<executions>

--- a/src/main/java/com/coincoinche/HelloController.java
+++ b/src/main/java/com/coincoinche/HelloController.java
@@ -3,7 +3,9 @@ package com.coincoinche;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Simple controller to test Spring Boot. */
+/**
+ * Simple controller to test Spring Boot. TODO nockty: remove this code when no longer necessary.
+ */
 @RestController
 public class HelloController {
 

--- a/src/test/java/com/coincoinche/CoincoincheApplicationTests.java
+++ b/src/test/java/com/coincoinche/CoincoincheApplicationTests.java
@@ -8,6 +8,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+// TODO nockty: remove this code when no longer necessary.
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class CoincoincheApplicationTests {

--- a/src/test/java/com/coincoinche/CoincoincheApplicationTests.java
+++ b/src/test/java/com/coincoinche/CoincoincheApplicationTests.java
@@ -1,20 +1,19 @@
 package com.coincoinche;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 // TODO nockty: remove this code when no longer necessary.
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class CoincoincheApplicationTests {
 
-  @Autowired
-  private HelloController controller;
+  @Autowired private HelloController controller;
 
   @Test
   public void contextLoads() {

--- a/src/test/java/com/coincoinche/HelloControllerIT.java
+++ b/src/test/java/com/coincoinche/HelloControllerIT.java
@@ -14,7 +14,10 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
-/** Full-stack integration test for the Hello controller. */
+/**
+ * Full-stack integration test for the Hello controller. TODO nockty: remove this code when no
+ * longer necessary.
+ */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class HelloControllerIT {

--- a/src/test/java/com/coincoinche/HelloControllerIT.java
+++ b/src/test/java/com/coincoinche/HelloControllerIT.java
@@ -1,0 +1,38 @@
+package com.coincoinche;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.net.URL;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/** Full-stack integration test for the Hello controller. */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class HelloControllerIT {
+
+  @LocalServerPort private int port;
+
+  private URL base;
+
+  @Autowired private TestRestTemplate template;
+
+  @Before
+  public void setUp() throws Exception {
+    this.base = new URL("http://localhost:" + port + "/greetings");
+  }
+
+  @Test
+  public void getHello() throws Exception {
+    ResponseEntity<String> response = template.getForEntity(base.toString(), String.class);
+    assertThat(response.getBody(), equalTo("Greetings from Spring Boot!"));
+  }
+}

--- a/src/test/java/com/coincoinche/HelloControllerTest.java
+++ b/src/test/java/com/coincoinche/HelloControllerTest.java
@@ -14,7 +14,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-/** Unit tests for the Hello controller. */
+/** Unit tests for the Hello controller. TODO nockty: remove this code when no longer necessary. */
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/src/test/java/com/coincoinche/HelloControllerTest.java
+++ b/src/test/java/com/coincoinche/HelloControllerTest.java
@@ -1,0 +1,31 @@
+package com.coincoinche;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+/** Unit tests for the Hello controller. */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class HelloControllerTest {
+
+  @Autowired private MockMvc mvc;
+
+  @Test
+  public void getHello() throws Exception {
+    mvc.perform(MockMvcRequestBuilders.get("/greetings").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().string(equalTo("Greetings from Spring Boot!")));
+  }
+}


### PR DESCRIPTION
- Add tests which should obviously be deleted in the future, but for now we can use them as a reference for future testing. There is an example of unit test, as well as an example of integration test.
- small update in `README` and formatting