### PR TITLE
Remove front end dependency on event reception order

### DIFF
--- a/server/src/main/java/com/coincoinche/events/CardPlayedEvent.java
+++ b/server/src/main/java/com/coincoinche/events/CardPlayedEvent.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 
 public class CardPlayedEvent extends Event {
   private String card;
+  private int playerIndex;
 
   /**
    * Event sent by the client when the player plays a card during the main phase of the round.
@@ -11,12 +12,17 @@ public class CardPlayedEvent extends Event {
    * @param card - String corresponding to the card short name.
    */
   @JsonCreator
-  public CardPlayedEvent(String card) {
+  public CardPlayedEvent(int playerIndex, String card) {
     super(EventType.CARD_PLAYED);
     this.card = card;
+    this.playerIndex = playerIndex;
   }
 
   public String getCard() {
     return card;
+  }
+
+  public int getPlayerIndex() {
+    return playerIndex;
   }
 }

--- a/server/src/main/java/com/coincoinche/events/PlayerBadeEvent.java
+++ b/server/src/main/java/com/coincoinche/events/PlayerBadeEvent.java
@@ -9,6 +9,11 @@ public class PlayerBadeEvent extends Event {
   private int value;
   private Suit suit;
   private MoveType moveType;
+  private int playerIndex;
+
+  public PlayerBadeEvent() {
+    super(EventType.PLAYER_BADE);
+  }
 
   /**
    * Event sent by the client when the player did a special bidding during the bidding phase of the
@@ -16,10 +21,11 @@ public class PlayerBadeEvent extends Event {
    *
    * @param special - the value of the special bidding.
    */
-  public PlayerBadeEvent(MoveBidding.Special special) {
+  public PlayerBadeEvent(int playerIndex, MoveBidding.Special special) {
     super(EventType.PLAYER_BADE);
     this.special = special;
     this.moveType = MoveType.SPECIAL_BIDDING;
+    this.playerIndex = playerIndex;
   }
 
   /**
@@ -29,11 +35,14 @@ public class PlayerBadeEvent extends Event {
    * @param value - the value of the bidding.
    * @param suit - the suit of the bidding.
    */
-  public PlayerBadeEvent(int value, Suit suit) {
+  public PlayerBadeEvent(
+      int playerIndex, MoveType moveType, int value, Suit suit, MoveBidding.Special special) {
     super(EventType.PLAYER_BADE);
     this.value = value;
     this.suit = suit;
-    this.moveType = MoveType.CONTRACT_BIDDING;
+    this.moveType = moveType;
+    this.special = special;
+    this.playerIndex = playerIndex;
   }
 
   public MoveBidding.Special getSpecial() {
@@ -50,5 +59,9 @@ public class PlayerBadeEvent extends Event {
 
   public MoveType getMoveType() {
     return moveType;
+  }
+
+  public int getPlayerIndex() {
+    return playerIndex;
   }
 }

--- a/server/src/main/java/com/coincoinche/websockets/controllers/GameController.java
+++ b/server/src/main/java/com/coincoinche/websockets/controllers/GameController.java
@@ -117,6 +117,7 @@ public class GameController {
       @Payload PlayerBadeEvent event) {
     CoincheGame game = this.repository.getGame(gameId);
     MoveBidding move = MoveBidding.fromEvent(event);
+    int playerIndex = game.getCurrentRound().getCurrentPlayerIndex();
     try {
       move.applyOnGame(game);
       this.template.convertAndSend(getBroadcastTopicPath(gameId), event);
@@ -129,7 +130,8 @@ public class GameController {
         // make the player pass if the bidding move is invalid.
         MoveBidding.passMove().applyOnGame(game);
         this.template.convertAndSend(
-            getBroadcastTopicPath(gameId), new PlayerBadeEvent(MoveBidding.Special.PASS));
+            getBroadcastTopicPath(gameId),
+            new PlayerBadeEvent(playerIndex, MoveBidding.Special.PASS));
       } catch (IllegalMoveException illegalPassMoveException) {
         illegalPassMoveException.printStackTrace();
       }
@@ -155,8 +157,9 @@ public class GameController {
       @DestinationVariable String username,
       @Payload CardPlayedEvent event) {
     CoincheGame game = this.repository.getGame(gameId);
-
     MovePlaying move = MovePlaying.fromEvent(event);
+    int playerIndex = game.getCurrentRound().getCurrentPlayerIndex();
+
     try {
       GameResult<Team> result = move.applyOnGame(game);
       this.template.convertAndSend(getBroadcastTopicPath(gameId), event);
@@ -184,7 +187,8 @@ public class GameController {
         firstLegalMove.applyOnGame(game);
 
         this.template.convertAndSend(
-            getBroadcastTopicPath(gameId), new CardPlayedEvent(firstLegalMove.toJson()));
+            getBroadcastTopicPath(gameId),
+            new CardPlayedEvent(playerIndex, firstLegalMove.toJson()));
       } catch (IllegalMoveException illegalPassMoveException) {
         illegalPassMoveException.printStackTrace();
       }

--- a/web-ui/src/game-engine/gameStateInit.ts
+++ b/web-ui/src/game-engine/gameStateInit.ts
@@ -9,5 +9,7 @@ export const gameStateInit = (usernames: string[], bottomPlayerIndex: number): G
   currentPhase: GameRoundPhase.BIDDING,
   currentlySelectedContract: null,
   lastBiddingContract: {},
-  legalMoves: []
+  legalBiddingMoves: [],
+  legalPlayingMoves: [],
+  currentTrick: {},
 });

--- a/web-ui/src/game-engine/gameStateModifiers.ts
+++ b/web-ui/src/game-engine/gameStateModifiers.ts
@@ -13,7 +13,7 @@ import {
 } from '../websocket/events/types';
 import {GameRoundPhase, GameState, LegalBiddingMove, Position} from "./gameStateTypes";
 import {CardValue} from "../assets/cards";
-import {positionFromUsername} from "./playerPositionning";
+import {positionFromPlayerIndex, positionFromUsername} from "./playerPositionning";
 
 class InvalidEventError extends Error {}
 
@@ -72,10 +72,10 @@ export class GameStateModifier {
     return this;
   };
 
-  addCardToCurrentTrick = (position: Position, card: CardValue) => {
+  addCardToCurrentTrick = (playerIndex: number, card: CardValue) => {
     this.gameState.currentTrick = {
       ...this.gameState.currentTrick,
-      [position]: card,
+      [positionFromPlayerIndex(playerIndex, this.gameState.usernamesByPosition, this.gameState.usernames)]: card,
     };
     return this;
   };
@@ -112,7 +112,7 @@ const applyPlayerBadeEvent = (event: PlayerBadeEvent, gameState: GameState): Gam
 
 const applyCardPlayedEvent = (event: CardPlayedEvent, gameState: GameState): GameState => {
   return new GameStateModifier(gameState)
-    .addCardToCurrentTrick(gameState.currentPlayer, event.card)
+    .addCardToCurrentTrick(event.playerIndex, event.card)
     .retrieveNewState();
 };
 

--- a/web-ui/src/game-engine/gameStateModifiers.ts
+++ b/web-ui/src/game-engine/gameStateModifiers.ts
@@ -15,7 +15,6 @@ import {GameRoundPhase, GameState, LegalBiddingMove, Position} from "./gameState
 import {CardValue} from "../assets/cards";
 import {positionFromUsername} from "./playerPositionning";
 
-class IllegalStateModificationError extends Error {}
 class InvalidEventError extends Error {}
 
 export class GameStateModifier {
@@ -39,33 +38,21 @@ export class GameStateModifier {
   };
 
   setLegalBiddingMoves = (legalMoves: LegalBiddingMove[]) => {
-    if (this.gameState.currentPhase !== GameRoundPhase.BIDDING) {
-      throw new IllegalStateModificationError('Can only set legal bidding moves during the BIDDING phase');
-    }
-    this.gameState.legalMoves = legalMoves;
+    this.gameState.legalBiddingMoves = legalMoves;
     return this;
   };
 
   setLegalPlayingMoves = (legalMoves: CardValue[]) => {
-    if (this.gameState.currentPhase !== GameRoundPhase.MAIN) {
-      throw new IllegalStateModificationError('Can only set legal playing moves during the MAIN phase');
-    }
-    this.gameState.legalMoves = legalMoves;
+    this.gameState.legalPlayingMoves = legalMoves;
     return this;
   };
 
   setLastBiddingContract = (contract: LegalBiddingMove) => {
-    if (this.gameState.currentPhase !== GameRoundPhase.BIDDING) {
-      return this;
-    }
     this.gameState.lastBiddingContract = contract;
     return this;
   };
 
   setCurrentlySelectedContract = (contract: Partial<LegalBiddingMove | null>) => {
-    if (this.gameState.currentPhase !== GameRoundPhase.BIDDING) {
-      return this;
-    }
     this.gameState.currentlySelectedContract = contract;
     return this;
   };
@@ -81,17 +68,11 @@ export class GameStateModifier {
   };
 
   resetCurrentTrick = () => {
-    if (this.gameState.currentPhase !== GameRoundPhase.MAIN) {
-      return this;
-    }
     this.gameState.currentTrick = {};
     return this;
   };
 
   addCardToCurrentTrick = (position: Position, card: CardValue) => {
-    if (this.gameState.currentPhase !== GameRoundPhase.MAIN) {
-      return this;
-    }
     this.gameState.currentTrick = {
       ...this.gameState.currentTrick,
       [position]: card,
@@ -157,16 +138,16 @@ const applyRoundPhaseStartedEvent = ({ phase }: RoundPhaseStartedEvent, gameStat
     .retrieveNewState();
 };
 
-const applyBiddingTurnStartedEvent = ({ legalMoves, playerIndex }: BiddingTurnStartedEvent, gameState: GameState): GameState => {
+const applyBiddingTurnStartedEvent = ({ legalBiddingMoves, playerIndex }: BiddingTurnStartedEvent, gameState: GameState): GameState => {
   return new GameStateModifier(gameState)
-    .setLegalBiddingMoves(legalMoves)
+    .setLegalBiddingMoves(legalBiddingMoves)
     .setCurrentPlayer(playerIndex)
     .retrieveNewState();
 };
 
-const applyPlayingTurnStartedEvent = ({ legalMoves, playerIndex }: PlayingTurnStartedEvent, gameState: GameState): GameState => {
+const applyPlayingTurnStartedEvent = ({ legalPlayingMoves, playerIndex }: PlayingTurnStartedEvent, gameState: GameState): GameState => {
   return new GameStateModifier(gameState)
-    .setLegalPlayingMoves(legalMoves)
+    .setLegalPlayingMoves(legalPlayingMoves)
     .setCurrentPlayer(playerIndex)
     .retrieveNewState();
 };

--- a/web-ui/src/game-engine/gameStateTypes.ts
+++ b/web-ui/src/game-engine/gameStateTypes.ts
@@ -69,13 +69,12 @@ export type GameState = {
   usernamesByPosition: UsernamesByPosition;
   currentPlayer: Position;
   cardsInHand: CardValue[];
-} & ({
-  currentPhase: GameRoundPhase.BIDDING;
+
+  currentPhase: GameRoundPhase;
   currentlySelectedContract: Partial<LegalBiddingMove> | null;
   lastBiddingContract: Partial<LegalBiddingMove>;
-  legalMoves: LegalBiddingMove[];
-} | {
-  currentPhase: GameRoundPhase.MAIN;
+  legalBiddingMoves: LegalBiddingMove[];
+
   currentTrick: Trick;
-  legalMoves: CardValue[];
-});
+  legalPlayingMoves: CardValue[];
+};

--- a/web-ui/src/game-engine/playerPositionning.ts
+++ b/web-ui/src/game-engine/playerPositionning.ts
@@ -1,24 +1,5 @@
 import {Position, UsernamesByPosition} from "./gameStateTypes";
 
-export const getNextPlayer = (currentPlayer: Position): Position => {
-  if (currentPlayer === Position.bottom) {
-    return Position.left;
-  }
-
-  if (currentPlayer === Position.left) {
-    return Position.top;
-  }
-
-  if (currentPlayer === Position.top) {
-    return Position.right;
-  }
-
-  if (currentPlayer === Position.right) {
-    return Position.bottom;
-  }
-  throw new Error('Unknown position');
-};
-
 export const buildUsernamesByPosition = (usernames: string[], bottomPlayerIndex: number): UsernamesByPosition => ({
   [Position.bottom]: usernames[bottomPlayerIndex],
   [Position.left]: usernames[(bottomPlayerIndex + 1) % usernames.length],
@@ -28,3 +9,9 @@ export const buildUsernamesByPosition = (usernames: string[], bottomPlayerIndex:
 
 export const positionFromUsername = (username: string, usernamesByPosition: UsernamesByPosition): Position =>
   Object.keys(usernamesByPosition).find((position) => usernamesByPosition[position as Position] === username) as Position;
+
+export const playerIndexFromPosition = (position: Position, usernamesByPosition: UsernamesByPosition, usernames: string[]) =>
+  usernames.indexOf(usernamesByPosition[position]);
+
+export const positionFromPlayerIndex = (playerIndex: number, usernamesByPosition: UsernamesByPosition, usernames: string[]) =>
+  positionFromUsername(usernames[playerIndex], usernamesByPosition);

--- a/web-ui/src/pages/MainGame/MainGameScreen.tsx
+++ b/web-ui/src/pages/MainGame/MainGameScreen.tsx
@@ -106,7 +106,7 @@ class MainGameScreen extends React.Component<Props, State> {
     if (
         this.state.currentPhase !== GameRoundPhase.MAIN ||
         !this.state.cardsInHand.includes(card) ||
-        !this.state.legalMoves.includes(card) ||
+        !this.state.legalPlayingMoves.includes(card) ||
         player !== this.state.currentPlayer
     ) {
       return;
@@ -149,13 +149,13 @@ class MainGameScreen extends React.Component<Props, State> {
     let authorisedSpecialBiddings: SpecialBidding[] = [];
     let lastBiddingContract: Partial<LegalBiddingMove>;
     if (this.state.currentPhase === GameRoundPhase.BIDDING) {
-      authorisedContractValues = this.state.legalMoves
+      authorisedContractValues = this.state.legalBiddingMoves
         .filter(move => move.moveType === MoveType.CONTRACT_BIDDING)
         .map(move => (move as ContractBiddingMove).value);
-      authorisedContractSuits = this.state.legalMoves
+      authorisedContractSuits = this.state.legalBiddingMoves
         .filter(move => move.moveType === MoveType.CONTRACT_BIDDING)
         .map(move => (move as ContractBiddingMove).suit);
-      authorisedSpecialBiddings = this.state.legalMoves
+      authorisedSpecialBiddings = this.state.legalBiddingMoves
         .filter(move => move.moveType === MoveType.SPECIAL_BIDDING)
         .map(move => (move as SpecialBiddingMove).bidding);
 
@@ -166,7 +166,7 @@ class MainGameScreen extends React.Component<Props, State> {
     let currentTrick: Trick;
     if (this.state.currentPhase === GameRoundPhase.MAIN) {
       legalCardsToPlay = this.state.cardsInHand.map(
-        (cardsInHand: CardValue) => (this.state.legalMoves as CardValue[]).includes(cardsInHand)
+        (cardsInHand: CardValue) => (this.state.legalPlayingMoves as CardValue[]).includes(cardsInHand)
       );
       currentTrick = this.state.currentTrick;
     }

--- a/web-ui/src/pages/MainGame/MainGameScreen.tsx
+++ b/web-ui/src/pages/MainGame/MainGameScreen.tsx
@@ -21,8 +21,8 @@ import {
 import {gameStateInit} from "../../game-engine/gameStateInit";
 import {applyEvent, GameStateModifier} from "../../game-engine/gameStateModifiers";
 import {inboundGameEventParser, outboundGameEventConverter} from "../../websocket/events/game";
-import {withRouter} from "react-router";
-import {RouteComponentProps} from "react-router";
+import {RouteComponentProps, withRouter} from "react-router";
+import {playerIndexFromPosition} from "../../game-engine/playerPositionning";
 
 const CLEAN_TRICK_TIMOUT_MS = 2000;
 
@@ -117,6 +117,7 @@ class MainGameScreen extends React.Component<Props, State> {
       outboundGameEventConverter[EventType.CARD_PLAYED]({
         type: EventType.CARD_PLAYED,
         card,
+        playerIndex: playerIndexFromPosition(Position.bottom, this.state.usernamesByPosition, this.state.usernames),
       })
     );
 
@@ -131,6 +132,7 @@ class MainGameScreen extends React.Component<Props, State> {
   onContractPicked = (biddingMove: LegalBiddingMove) => {
     const event: PlayerBadeEvent = {
       type: EventType.PLAYER_BADE,
+      playerIndex: playerIndexFromPosition(Position.bottom, this.state.usernamesByPosition, this.state.usernames),
       ...biddingMove
     };
 

--- a/web-ui/src/pages/MainMenu/MainMenu.tsx
+++ b/web-ui/src/pages/MainMenu/MainMenu.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import {Link} from "react-router-dom";
-import casual from "../../assets/menu/casual.png";
-import ranked from "../../assets/menu/ranked.png";
-import ladder from "../../assets/menu/ladder.png";
 
 import logo from '../../assets/coincoinche_logo.png';
-import Card from "../../components/cards/Card";
 
 type State = {};
 

--- a/web-ui/src/websocket/events/game.ts
+++ b/web-ui/src/websocket/events/game.ts
@@ -99,7 +99,7 @@ export const inboundGameEventParser: { [type in EventType]?: (event: any) => Eve
     });
     return {
       type: EventType.BIDDING_TURN_STARTED,
-      legalMoves,
+      legalBiddingMoves: legalMoves,
       playerIndex,
     }
   },
@@ -108,7 +108,7 @@ export const inboundGameEventParser: { [type in EventType]?: (event: any) => Eve
     const { legalMoves, playerIndex } = event;
     return {
       type: EventType.PLAYING_TURN_STARTED,
-      legalMoves,
+      legalPlayingMoves: legalMoves,
       playerIndex,
     }
   },

--- a/web-ui/src/websocket/events/game.ts
+++ b/web-ui/src/websocket/events/game.ts
@@ -30,13 +30,14 @@ const suitLetterParser = (suitLetter: string): Suit => {
 
 export const inboundGameEventParser: { [type in EventType]?: (event: any) => Event } = {
   [EventType.PLAYER_BADE]: (event: any): PlayerBadeEvent => {
-    const { value, suit, moveType, special } = event;
+    const { value, suit, moveType, special, playerIndex } = event;
     if (moveType === MoveType.CONTRACT_BIDDING) {
       return {
         type: EventType.PLAYER_BADE,
         moveType: MoveType.CONTRACT_BIDDING,
         value: value.toString(),
         suit: suit.toLowerCase(),
+        playerIndex,
       }
     }
 
@@ -45,6 +46,7 @@ export const inboundGameEventParser: { [type in EventType]?: (event: any) => Eve
         type: EventType.PLAYER_BADE,
         moveType: MoveType.SPECIAL_BIDDING,
         bidding: special,
+        playerIndex,
       }
     }
 
@@ -52,10 +54,11 @@ export const inboundGameEventParser: { [type in EventType]?: (event: any) => Eve
   },
 
   [EventType.CARD_PLAYED]: (event: any): CardPlayedEvent => {
-    const { card } = event;
+    const { card, playerIndex } = event;
     return {
       type: EventType.CARD_PLAYED,
       card,
+      playerIndex,
     }
   },
 

--- a/web-ui/src/websocket/events/types.ts
+++ b/web-ui/src/websocket/events/types.ts
@@ -65,13 +65,13 @@ export type RoundPhaseStartedEvent = {
 
 export type BiddingTurnStartedEvent = {
   type: EventType.BIDDING_TURN_STARTED,
-  legalMoves: LegalBiddingMove[],
+  legalBiddingMoves: LegalBiddingMove[],
   playerIndex: number,
 }
 
 export type PlayingTurnStartedEvent = {
   type: EventType.PLAYING_TURN_STARTED,
-  legalMoves: CardValue[],
+  legalPlayingMoves: CardValue[],
   playerIndex: number,
 }
 

--- a/web-ui/src/websocket/events/types.ts
+++ b/web-ui/src/websocket/events/types.ts
@@ -46,10 +46,12 @@ export type GameFinishedEvent = {
 
 export type PlayerBadeEvent = {
   type: EventType.PLAYER_BADE,
+  playerIndex: number,
 } & LegalBiddingMove;
 
 export type CardPlayedEvent = {
   type: EventType.CARD_PLAYED,
+  playerIndex: number,
   card: CardValue,
 };
 


### PR DESCRIPTION
Communications events between front end and back end should not rely on the order they are received by the front end.
This PR fixes the front-end so that it does not rely on the order of reception of some events.

This fixes the UI glitch where a player would not see the correct tricks 🎉 