### PR TITLE
Display previous trick for 2.5 seconds

### DIFF
--- a/server/src/main/java/com/coincoinche/engine/GameStatePlaying.java
+++ b/server/src/main/java/com/coincoinche/engine/GameStatePlaying.java
@@ -28,7 +28,6 @@ import java.util.stream.StreamSupport;
 @JsonSerialize(using = GameStatePlayingSerializer.class)
 public class GameStatePlaying implements GameStateTerminal {
   private static final int MAX_TRICK_NUMBER = 8;
-  private int currentTrickNumber;
   private Trick currentTrick;
   private Player lastTrickMaster;
   private Contract contract;
@@ -36,13 +35,12 @@ public class GameStatePlaying implements GameStateTerminal {
   private Map<Player, Integer> playerPoints = new HashMap<>();
   private List<Team> teams;
   private int multiplier = 1;
+  private List<Trick> trickHistory = new ArrayList<>();
 
-  GameStatePlaying(
-      Player currentPlayer, Contract contract, Trick currentTrick, int currentTrickNumber) {
+  GameStatePlaying(Player currentPlayer, Contract contract, Trick currentTrick) {
     this.currentPlayer = currentPlayer;
     this.contract = contract;
     this.currentTrick = currentTrick;
-    this.currentTrickNumber = currentTrickNumber;
   }
 
   /**
@@ -55,7 +53,7 @@ public class GameStatePlaying implements GameStateTerminal {
   public static GameStatePlaying initialGameStatePlaying(Player firstPlayer, Contract contract) {
     Trick currentTrick = Trick.emptyTrick(contract.getSuit());
     // start state with trick #1
-    return new GameStatePlaying(firstPlayer, contract, currentTrick, 1);
+    return new GameStatePlaying(firstPlayer, contract, currentTrick);
   }
 
   @Override
@@ -184,7 +182,7 @@ public class GameStatePlaying implements GameStateTerminal {
     // add points to master
     Player master = currentTrick.getMaster();
     int points = currentTrick.getValue();
-    if (currentTrickNumber == 8) {
+    if (getCurrentTrickNumber() == 8) {
       // 10 de der
       points += 10;
     }
@@ -192,13 +190,13 @@ public class GameStatePlaying implements GameStateTerminal {
     // update last master
     lastTrickMaster = master;
     // clear trick
+    trickHistory.add(currentTrick);
     currentTrick = Trick.emptyTrick(getTrumpSuit());
-    currentTrickNumber++;
   }
 
   @Override
   public boolean mustChange() {
-    return currentTrickNumber > MAX_TRICK_NUMBER;
+    return getCurrentTrickNumber() > MAX_TRICK_NUMBER;
   }
 
   public void setTeams(List<Team> teams) {
@@ -220,11 +218,15 @@ public class GameStatePlaying implements GameStateTerminal {
   }
 
   public int getCurrentTrickNumber() {
-    return currentTrickNumber;
+    return trickHistory.size() + 1;
   }
 
   public Trick getCurrentTrick() {
     return currentTrick;
+  }
+
+  public List<Trick> getTrickHistory() {
+    return trickHistory;
   }
 
   public Contract getContract() {

--- a/server/src/main/java/com/coincoinche/engine/serialization/json/GameStatePlayingSerializer.java
+++ b/server/src/main/java/com/coincoinche/engine/serialization/json/GameStatePlayingSerializer.java
@@ -7,6 +7,7 @@ import com.coincoinche.engine.teams.Player;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
+import java.util.List;
 
 /** Custom Serializer for GameStatePlaying objects. */
 public class GameStatePlayingSerializer extends GameStateSerializer<GameStatePlaying> {
@@ -22,11 +23,9 @@ public class GameStatePlayingSerializer extends GameStateSerializer<GameStatePla
     super(t);
   }
 
-  private void writeCurrentTrick(GameStatePlaying state, JsonGenerator gen) throws IOException {
-    gen.writeFieldName("currentTrick");
+  private void writeTrick(int trickNumber, Trick trick, JsonGenerator gen) throws IOException {
     gen.writeStartObject();
-    gen.writeNumberField("no", state.getCurrentTrickNumber());
-    Trick trick = state.getCurrentTrick();
+    gen.writeNumberField("no", trickNumber);
     gen.writeFieldName("cards");
     gen.writeStartObject();
     for (Player player : trick.getPlayers()) {
@@ -34,6 +33,21 @@ public class GameStatePlayingSerializer extends GameStateSerializer<GameStatePla
     }
     gen.writeEndObject();
     gen.writeEndObject();
+  }
+
+  private void writePreviousTrick(GameStatePlaying state, JsonGenerator gen) throws IOException {
+    List<Trick> trickHistory = state.getTrickHistory();
+    gen.writeFieldName("previousTrick");
+    if (trickHistory.isEmpty()) {
+      gen.writeNull();
+      return;
+    }
+    writeTrick(state.getCurrentTrickNumber() - 1, trickHistory.get(trickHistory.size() - 1), gen);
+  }
+
+  private void writeCurrentTrick(GameStatePlaying state, JsonGenerator gen) throws IOException {
+    gen.writeFieldName("currentTrick");
+    writeTrick(state.getCurrentTrickNumber(), state.getCurrentTrick(), gen);
   }
 
   @Override
@@ -49,6 +63,7 @@ public class GameStatePlayingSerializer extends GameStateSerializer<GameStatePla
       gen.writeNumberField("multiplier", multiplier);
     }
     writeCurrentTrick(value, gen);
+    writePreviousTrick(value, gen);
     gen.writeEndObject();
   }
 }

--- a/server/src/test/java/com/coincoinche/engine/GameStatePlayingTest.java
+++ b/server/src/test/java/com/coincoinche/engine/GameStatePlayingTest.java
@@ -40,7 +40,7 @@ public class GameStatePlayingTest extends GameEngineTestHelper {
       Trick currentTrick = createTrick(currentPlayer, trumpSuit);
       GameStatePlaying state =
           new GameStatePlaying(
-              currentPlayer, ContractFactory.createContract(80, trumpSuit), currentTrick, 1);
+              currentPlayer, ContractFactory.createContract(80, trumpSuit), currentTrick);
       List<Move> actual = state.getLegalMoves();
       int expectedSize = expected.size();
       int actualSize = actual.size();

--- a/web-ui/src/game-engine/gameStateInit.ts
+++ b/web-ui/src/game-engine/gameStateInit.ts
@@ -15,8 +15,10 @@ export const gameStateInit = (users: Player[], bottomPlayerIndex: number): GameS
     no: 1,
     cards: {}
   },
+  previousTrick: null,
   scores: {
     you: 0,
     them: 0
-  }
+  },
+  showPreviousTrick: false
 });

--- a/web-ui/src/game-engine/gameStateModifiers.ts
+++ b/web-ui/src/game-engine/gameStateModifiers.ts
@@ -66,6 +66,16 @@ export class GameStateModifier {
     return this;
   }
 
+  updatePreviousTrick = (trick: Trick) => {
+    this.gameState.previousTrick = trick;
+    return this;
+  }
+
+  setShowPreviousTrick = (b: boolean) => {
+    this.gameState.showPreviousTrick = b;
+    return this;
+  }
+
   retrieveNewState = () => this.gameState;
 }
 
@@ -85,6 +95,9 @@ const applyNewStateMessage = (msg: NewStateMessage, gameState: GameState): GameS
   if (msg.content.state.currentTrick) {
     gameStateModifier.updateCurrentTrick(msg.content.state.currentTrick);
   }
+  if (msg.content.state.previousTrick) {
+    gameStateModifier.updatePreviousTrick(msg.content.state.previousTrick);
+  }
   return gameStateModifier.retrieveNewState();
 }
 
@@ -96,3 +109,7 @@ export const applyMessage = (msg: Message, gameState: GameState): GameState => {
       throw new InvalidEventError('Unknown message type.');
   }
 };
+
+export const showPreviousTrick = (show: boolean, gameState: GameState): GameState => {
+  return new GameStateModifier(gameState).setShowPreviousTrick(show).retrieveNewState();
+}

--- a/web-ui/src/game-engine/gameStateTypes.ts
+++ b/web-ui/src/game-engine/gameStateTypes.ts
@@ -81,4 +81,6 @@ export type GameState = {
   highestBidding: Contract | null,
   legalMoves: LegalBiddingMove[] | LegalPlayingMove[];
   currentTrick: Trick;
+  previousTrick: Trick | null;
+  showPreviousTrick: boolean;
 };

--- a/web-ui/src/pages/MainGame/MainGameScreen.tsx
+++ b/web-ui/src/pages/MainGame/MainGameScreen.tsx
@@ -116,14 +116,6 @@ class MainGameScreen extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Readonly<InjectedProps>): void {
-    if (this.state.currentPhase === GameRoundPhase.MAIN) {
-      setTimeout(() => {
-        this.setState(prevState =>
-          new GameStateModifier(prevState).updateCurrentTrick(this.state.currentTrick).retrieveNewState()
-        )
-      }, UPDATE_TRICK_TIMOUT_MS)
-    }
-
     if (!prevProps.socketConnected && this.props.socketConnected) {
       this.props.subscribe(getGameTopic(this.props.gameId, this.props.username));
       this.props.subscribe(getBroadcastGameTopic(this.props.gameId));

--- a/web-ui/src/pages/MainGame/MainGameScreen.tsx
+++ b/web-ui/src/pages/MainGame/MainGameScreen.tsx
@@ -18,14 +18,14 @@ import {
   LegalPlayingMove,
 } from "../../game-engine/gameStateTypes";
 import {gameStateInit} from "../../game-engine/gameStateInit";
-import {GameStateModifier, applyMessage} from "../../game-engine/gameStateModifiers";
+import {GameStateModifier, applyMessage, showPreviousTrick} from "../../game-engine/gameStateModifiers";
 import {inboundGameMessageParser, outboundGameEventConverter} from "../../websocket/messages/game";
 import {RouteComponentProps, withRouter} from "react-router";
 import {playerIndexFromPosition} from "../../game-engine/playerPositionning";
 import ContractComponent from '../../components/ContractComponent';
 import ScoresComponent from '../../components/ScoresComponent';
 
-const UPDATE_TRICK_TIMOUT_MS = 2000;
+const SHOW_PREVIOUS_TRICK_TIMEOUT_MS = 2500;
 
 const hasTrickChanged = (prevTrick: Trick, currTrick: Trick): boolean => {
   let i = 0;
@@ -112,7 +112,8 @@ class MainGameScreen extends React.Component<Props, State> {
       return true;
     }
     // main phase
-    return hasTrickChanged(this.state.currentTrick, nexState.currentTrick);
+    return hasTrickChanged(this.state.currentTrick, nexState.currentTrick)
+      || this.state.showPreviousTrick !== nexState.showPreviousTrick;
   }
 
   componentDidUpdate(prevProps: Readonly<InjectedProps>): void {
@@ -124,7 +125,12 @@ class MainGameScreen extends React.Component<Props, State> {
 
   applyMessageToState = (messageType: MessageType, jsonMsg: string) => {
     const msg = inboundGameMessageParser[messageType]!(jsonMsg);
-    this.setState(prevState => applyMessage(msg, prevState))
+    this.setState(prevState => applyMessage(msg, prevState));
+    // if trick is empty, let previous trick so that players see it before it's removed
+    if (this.state.currentTrick.no > 0 && Object.entries(this.state.currentTrick.cards).length === 0) {
+      this.setState(prevState => showPreviousTrick(true, prevState));
+      setTimeout(() => { this.setState(prevState => showPreviousTrick(false, prevState)); }, SHOW_PREVIOUS_TRICK_TIMEOUT_MS);
+    }
   };
 
   onCardPlayed = (player: Position, card: CardValue) => {
@@ -195,13 +201,17 @@ class MainGameScreen extends React.Component<Props, State> {
     }
 
     let legalCardsToPlay: boolean[] = [];
-    let currentTrick: Trick | null;
+    let currentTrick: Trick | null = null;
     if (this.state.currentPhase === GameRoundPhase.MAIN) {
       legalCardsToPlay = this.state.cards[this.props.username].map(
         (card: CardValue) =>
           (this.state.legalMoves as LegalPlayingMove[]).map((m: LegalPlayingMove) => m.card).includes(card)
       );
       currentTrick = this.state.currentTrick;
+    }
+    let previousTrick: Trick | null = null;
+    if (this.state.currentPhase === GameRoundPhase.MAIN && this.state.previousTrick) {
+      previousTrick = this.state.previousTrick;
     }
 
     const topUsername: string = this.state.usernamesByPosition[Position.top];
@@ -258,12 +268,20 @@ class MainGameScreen extends React.Component<Props, State> {
           />
         }
         {
-          currentPhase === GameRoundPhase.MAIN && <CardBoard
+          currentPhase === GameRoundPhase.MAIN && !this.state.showPreviousTrick && <CardBoard
             left={currentTrick!.cards[this.state.usernamesByPosition[Position.left]]}
             right={currentTrick!.cards[this.state.usernamesByPosition[Position.right]]}
             bottom={currentTrick!.cards[this.state.usernamesByPosition[Position.bottom]]}
             top={currentTrick!.cards[this.state.usernamesByPosition[Position.top]]}
           />
+        }
+        {
+          currentPhase === GameRoundPhase.MAIN && this.state.showPreviousTrick && <CardBoard
+            left={previousTrick!.cards[this.state.usernamesByPosition[Position.left]]}
+            right={previousTrick!.cards[this.state.usernamesByPosition[Position.right]]}
+            bottom={previousTrick!.cards[this.state.usernamesByPosition[Position.bottom]]}
+            top={previousTrick!.cards[this.state.usernamesByPosition[Position.top]]}
+        />
         }
         <HandOfCards
           cards={this.state.cards[rightUsername] || []}

--- a/web-ui/src/websocket/messages/game.ts
+++ b/web-ui/src/websocket/messages/game.ts
@@ -93,6 +93,10 @@ export const inboundGameMessageParser: { [type in MessageType]?: (msg: any) => M
           currentTrick: {
             no: msg.content.state.currentTrick ? msg.content.state.currentTrick.no : 1,
             cards: {}
+          },
+          previousTrick: {
+            no: msg.content.state.previousTrick ? msg.content.state.previousTrick.no : 0,
+            cards: {}
           }
         },
         scores: {
@@ -122,7 +126,16 @@ export const inboundGameMessageParser: { [type in MessageType]?: (msg: any) => M
         }
       }
     }
-
+    if (msg.content.state.previousTrick) {
+      for (const username in msg.content.state.previousTrick.cards) {
+        if (Object.prototype.hasOwnProperty.call(msg.content.state.previousTrick.cards, username)) {
+        // @ts-ignore
+        newStateMessage.content.state.previousTrick.cards[username] =
+          // @ts-ignore
+          CardValue[msg.content.state.previousTrick.cards[username].toLowerCase()];
+        }
+      }
+    }
     // @ts-ignore
     return newStateMessage;
   }

--- a/web-ui/src/websocket/messages/types.ts
+++ b/web-ui/src/websocket/messages/types.ts
@@ -50,6 +50,7 @@ export type NewStateMessage = {
       currentPlayer: string,
       highestBidding?: Contract
       currentTrick?: Trick
+      previousTrick?: Trick | null
       multiplier: number
     },
     cards: {


### PR DESCRIPTION
Let the previous trick be displayed for 2.5 seconds before disappearing, to let every player see what it looked like.

Weakness of the current implementation: this doesn't work for the last trick of the round... Maybe we should add the previous trick to the bidding phase serialization too but I think we can see that later. There are other priorities for now. (Also, it's possible to implement this when we implement a end-of-round screen!)